### PR TITLE
Fix URL schema

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -544,7 +544,7 @@ def main():
             print("\nERROR: The \"class_uid:\"", str(EVENT['class_uid']),"is not defined within OCSF", str(EVENT['metadata']['version']))
             sys.exit()
         # Pull OCSF Schema from browser
-        url = ('https://schema.ocsf.io/' + str(EVENT['metadata']['version']) + '/schema/classes/' + url_class_name + '?profiles=' + urllib.parse.quote(url_profiles))
+        url = ('https://schema.ocsf.io/schema/' + str(EVENT['metadata']['version']) + '/classes/' + url_class_name + '?profiles=' + urllib.parse.quote(url_profiles))
         response = requests.get(url)
         ocsf_schema = json.loads(json.dumps(response.json()))
         # Write OCSF Schema to file


### PR DESCRIPTION
### Issue
The script currently attempts to access OCSF schema files using an incorrect URL structure. Specifically, it constructs URLs in the format (for example):
```
https://schema.ocsf.io/1.1.0/schema/classes/file_activity
```
However, the correct format (as used by https://schema.ocsf.io/) is:
```
https://schema.ocsf.io/schema/1.1.0/classes/file_activity
```

### Fix
This PR updates the script to use the correct lookup URL, ensuring compatibility with the current URL schema.

### Impact
None, other than the script can now correctly access the needed JSON schema files.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
